### PR TITLE
Migrate from rollup uglify to terser

### DIFF
--- a/templates/library/build/rollup.config.js
+++ b/templates/library/build/rollup.config.js
@@ -3,7 +3,7 @@ import vue from 'rollup-plugin-vue';
 import buble from 'rollup-plugin-buble';
 import commonjs from 'rollup-plugin-commonjs';
 import replace from 'rollup-plugin-replace';
-import uglify from 'rollup-plugin-uglify-es';
+import { terser } from 'rollup-plugin-terser';
 import minimist from 'minimist';
 
 const argv = minimist(process.argv.slice(2));
@@ -32,7 +32,7 @@ const config = {
 
 // Only minify browser (iife) version
 if (argv.format === 'iife') {
-  config.plugins.push(uglify());
+  config.plugins.push(terser());
 }
 
 export default config;

--- a/templates/library/library-package.json
+++ b/templates/library/library-package.json
@@ -30,7 +30,7 @@
     "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-uglify-es": "0.0.1",
+    "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-vue": "^4.6.2",
     "vue": "^2.5.22",
     "vue-template-compiler": "^2.5.22"

--- a/templates/single/build/rollup.config.js
+++ b/templates/single/build/rollup.config.js
@@ -3,7 +3,7 @@ import vue from 'rollup-plugin-vue';
 import buble from 'rollup-plugin-buble';
 import commonjs from 'rollup-plugin-commonjs';
 import replace from 'rollup-plugin-replace';
-import uglify from 'rollup-plugin-uglify-es';
+import { terser } from 'rollup-plugin-terser';
 import minimist from 'minimist';
 
 const argv = minimist(process.argv.slice(2));
@@ -32,7 +32,7 @@ const config = {
 
 // Only minify browser (iife) version
 if (argv.format === 'iife') {
-  config.plugins.push(uglify());
+  config.plugins.push(terser());
 }
 
 export default config;

--- a/templates/single/single-package.json
+++ b/templates/single/single-package.json
@@ -32,7 +32,7 @@
     "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-uglify-es": "0.0.1",
+    "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-vue": "^4.6.2",
     "vue": "^2.5.22",
     "vue-template-compiler": "^2.5.22"


### PR DESCRIPTION
"rollup-plugin-uglify-es" is deprecated and "rollup-plugin-terser" is suggested to use instead.
It causes the following warning:
`(!) uglify plugin: The transformBundle hook used by plugin uglify is deprecated. The renderChunk hook should be used instead.
`