### PR TITLE
Run build before publish

### DIFF
--- a/templates/library/library-package.json
+++ b/templates/library/library-package.json
@@ -21,6 +21,7 @@
 
   "scripts": {
     "serve": "vue-cli-service serve dev/serve.<% if (ts) { %>ts<% } else { %>js<% } %>",
+    "prepublishOnly": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
     "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
     "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format cjs",
     "build:es": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format es",

--- a/templates/single/single-package.json
+++ b/templates/single/single-package.json
@@ -21,6 +21,7 @@
 
   "scripts": {
     "serve": "vue-cli-service serve dev/serve.<% if (ts) { %>ts<% } else { %>js<% } %>",
+    "prepublishOnly": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
     "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
     "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format cjs",
     "build:es": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format es",


### PR DESCRIPTION
I use this library for 2 of my sfc projects and for many occasion, I accidentally publish into NPM without building the project.

I suggest an update to prevent accidental publish into NPM without building it.
Using `'prepublishOnly'` in `scripts` that will run before the package is prepared and packed, only on npm publish.

More Info: https://docs.npmjs.com/misc/scripts

For yarn and npm compatibility, doing this: `'prepublishOnly': 'npm build'` is not suggested.