### PR TITLE
Remove optional chaining and nullish coalescing

### DIFF
--- a/templates/library/src/lib-components/component.vue
+++ b/templates/library/src/lib-components/component.vue
@@ -33,7 +33,7 @@ export default /*#__PURE__*/<% if (version === 3) {%>defineComponent(<% } else i
     changedBy() {
       const { message } = this<% if (ts) { %> as SampleData<% } %>;
       if (!message.action) return 'initialized';
-      return `${message?.action} ${message.amount ?? ''}`.trim();
+      return `${message.action} ${message.amount || ''}`.trim();
     },
   },
   methods: {

--- a/templates/single/src/component.vue
+++ b/templates/single/src/component.vue
@@ -33,7 +33,7 @@ export default /*#__PURE__*/<% if (version === 3) {%>defineComponent(<% } else i
     changedBy() {
       const { message } = this<% if (ts) { %> as SampleData<% } %>;
       if (!message.action) return 'initialized';
-      return `${message?.action} ${message.amount ?? ''}`.trim();
+      return `${message.action} ${message.amount || ''}`.trim();
     },
   },
   methods: {


### PR DESCRIPTION
When starting out with `vue-sfc-rollup`, a common path may be to publish the default setup, import it into their own project and make sure it works before tweaking and adding new components in.

A common way to start projects with Vue is `vue-cli`, which when generating a Vue 2 project, does not come with support for optional chaining or nullish coalescing out of the box. As a result, when importing the default component into the project, it was blowing up (with an error message that threw me off the scent for over half a day until I finally realised what was going on, in hindsight it makes sense):

```
Module parse failed: Unexpected token (22:24)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|       } = this;
|       if (!message.action) return "initialized";
>       return `${message?.action} ${message.amount ?? ""}`.trim();
|     }
|
```

I don't believe there are any downsides to using the `||` operator instead of the `??` operator in this instance, but it's worth the author double checking in case there are edge cases I'm unaware of. Removing the optional chaining here would have no downsides too, as the preceding line references `message.action` directly so would itself blow up before the optional chaining line was executed. Testing this fix out by changing the line in the imported `dist/component-library.esm.js` to remove the optional chaining and nullish coalescing did the job for me and everything worked as expected.