### PR TITLE
Reuse the same npm command for build

### DIFF
--- a/templates/library/library-package.json
+++ b/templates/library/library-package.json
@@ -23,9 +23,9 @@
   "scripts": {
     "serve": "vue-cli-service serve dev/serve.<% if (ts) { %>ts<% } else { %>js<% } %>",
     "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
-    "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format cjs",
-    "build:es": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format es",
-    "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
+    "build:ssr": "npm run build -- --format cjs",
+    "build:es": "npm run build -- --format es",
+    "build:unpkg": "npm run build -- --format iife"
   },
 
   "dependencies": {


### PR DESCRIPTION
Just in case you want to add [`pre-` or `post-` scripts](https://docs.npmjs.com/cli/v7/using-npm/scripts#pre--post-scripts) for the `build` one.

For example, defining a:

```json5
{
  "scripts": {
    // ...
    "prebuild": "rimraf dist"
    // ...
  },
  "devDependencies": {
    // ...
    "rimraf": "latest"
    // ...
  }
}
```

This will `rimraf dist` for all the build commands.

As far as I know, this will also work if the user prefers to use [`yarn`](https://yarnpkg.com/) as their package manager.