### PR TITLE
Added: support for initial jest test scaffold

### DIFF
--- a/sfc-init.js
+++ b/sfc-init.js
@@ -17,6 +17,7 @@ const responses = {
   mode: '',
   npmName: '',
   componentName: '',
+  test: '',
   language: '',
   savePath: '',
 };
@@ -115,6 +116,16 @@ async function getName() {
         return (kebabName !== '');
       },
     });
+    questions.push({
+      type: 'select',
+      name: 'test',
+      message: 'What is the testing framework being used?',
+      choices: [
+        { title: 'None', value: 'none' },
+        { title: 'Jest', value: 'jest' },
+      ],
+      initial: 0,
+    });
   }
   const response = await prompts(
     questions,
@@ -128,6 +139,7 @@ async function getName() {
   );
   responses.npmName = response.npmName;
   responses.componentName = response.componentName ? response.componentName : tmpKebabName;
+  responses.test = response.test;
   responses.savePath = `./${tmpKebabName}`;
 }
 
@@ -185,6 +197,7 @@ function scaffold(data) {
     componentName: data.componentName,
     version: data.version,
     ts: data.language === 'ts',
+    test: data.test,
   };
   const files = {
     common: [
@@ -203,6 +216,8 @@ function scaffold(data) {
       { 'src/component.vue': `src/${data.componentName}.vue` },
       { 'single-package.json': 'package.json' },
       (data.language === 'ts') ? { 'single-component.d.ts': `${data.componentName}.d.ts` } : null,
+      (data.test === 'jest') ? 'jest.config.js' : null,
+      (data.test === 'jest') ? { 'tests/initial-test.spec.js': `tests/${data.componentName}.spec.js` } : null,
     ],
     library: [
       { 'src/lib-components/component.vue': `src/lib-components/${data.componentName}-sample.vue` },

--- a/templates/single/babel.config.js
+++ b/templates/single/babel.config.js
@@ -14,6 +14,26 @@ const buildPresets = [
   '@babel/preset-typescript',
 <% } -%>
 ];
+
 module.exports = {
-  presets: (process.env.NODE_ENV === 'development' ? devPresets : buildPresets),
-};
+  env: {
+    development: { presets: devPresets },
+    production: { presets: buildPresets },
+    test: {
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: {
+              node: 'current'
+            }
+          },
+        ],
+<% if (ts) { -%>
+        '@babel/preset-typescript',
+<% } -%>
+        '@vue/babel-preset-app'
+      ]
+    }
+  }
+}

--- a/templates/single/jest.config.js
+++ b/templates/single/jest.config.js
@@ -1,0 +1,53 @@
+<% if (ts) { -%>
+/** @typedef {import('ts-jest')} */
+/** @type {import('@jest/types').Config.InitialOptions} */
+<% } -%>
+const config = {
+<% if (ts) { -%>
+  globals: {
+    'vue-jest': {
+      tsConfig: './tsconfig.json',
+    },
+    'ts-jest': {
+      tsconfig: {
+        allowJs: true,
+      },
+    },
+  },
+<% } -%>
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  moduleFileExtensions: [
+<% if (ts) { -%>
+    'ts',
+<% } -%>
+    'js',
+    'vue',
+    'json',
+  ],
+  transform: {
+<% if (ts) { -%>
+    '^.+\\.(t|j)s$': 'ts-jest',
+<% } else { -%>
+    '\\.js$': 'babel-jest',
+<% } -%>
+    '.*\\.(vue)$': 'vue-jest',
+  },
+  collectCoverage: false,
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.vue',
+    '<rootDir>/src/**/*.js',
+<% if (ts) { -%>
+    '<rootDir>/src/**/*.ts',
+<% } -%>
+  ],
+  coveragePathIgnorePatterns: [
+    'node_modules',
+  ],
+  snapshotSerializers: [
+    'jest-serializer-vue',
+  ],
+};
+
+module.exports = config;

--- a/templates/single/single-package.json
+++ b/templates/single/single-package.json
@@ -21,6 +21,9 @@
   "sideEffects": false,
 
   "scripts": {
+<% if (test === 'jest') { -%>
+    "test": "jest",
+<% } -%>
     "serve": "vue-cli-service serve dev/serve.<% if (ts) { %>ts<% } else { %>js<% } %>",
     "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
     "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format cjs",
@@ -32,7 +35,6 @@
   },
 
   "devDependencies": {
-    "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
 <% if (ts) { -%>
     "@babel/preset-typescript": "^7.12.7",
@@ -42,7 +44,26 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.1",
     "@rollup/plugin-replace": "^2.3.4",
+<% if (test === 'jest' && ts) { -%>
+    "@types/jest": "^26.0.22",
+<% } -%>
     "@vue/cli-plugin-babel": "^4.5.10",
+<% if (test === 'jest') { -%>
+    <% if (version === 2) { -%>
+    "@vue/test-utils": "^1.1.3",
+    <% } else { -%>
+    "@vue/test-utils": "^2.0.0-rc.6",
+    <% } -%>
+<% } -%>
+    "babel-core": "7.0.0-bridge.0",
+<% if (test === 'jest' && !ts) { -%>
+    "babel-jest": "^26.6.3",
+    "babel-polyfill": "^6.26.0",
+<% } -%>
+<% if (test === 'jest') { -%>
+    "jest": "^26.6.3",
+    "jest-serializer-vue": "^2.0.2",
+<% } -%>
 <% if (ts) { -%>
     "@vue/cli-plugin-typescript": "^4.5.10",
 <% } -%>
@@ -67,6 +88,17 @@
 <% } -%>
 <% if (ts) { -%>
     "typescript": "^3.8.3",
+<% } -%>
+<% if (test === 'jest' && ts) { -%>
+    "ts-jest": "^26.5.4",
+<% } -%>
+<% if (test === 'jest') { -%>
+    <% if (version === 2) { -%>
+    "vue-jest": "^3.0.7",
+    <% } else { -%>
+    "core-js": "^3.10.2",
+    "vue-jest": "^5.0.0-alpha.7",
+    <% } -%>
 <% } -%>
 <% if (version === 3) { -%>
     "vue": "^3.0.5"

--- a/templates/single/tests/initial-test.spec.js
+++ b/templates/single/tests/initial-test.spec.js
@@ -1,0 +1,32 @@
+import {} from 'jest';
+// Doc: https://vue-test-utils.vuejs.org/api/
+<% if (version === 3) { -%>
+import { config, shallowMount } from '@vue/test-utils';
+<% } else { -%>
+import { createLocalVue, config, shallowMount } from '@vue/test-utils';
+<% } -%>
+import Component from '../src/<%-componentName%>.vue';
+
+<% if (version === 2) { -%>
+const localVue = createLocalVue();
+<% } -%>
+
+// Doc: https://vue-test-utils.vuejs.org/api/#config
+config.showDeprecationWarnings = true;
+
+describe('Component.vue', () => {
+  const wrapper = shallowMount(Component, {
+<% if (version === 2) { -%>
+    localVue,
+<% } -%>
+    propsData: {},
+  });
+
+  test('is a Vue instance', () => {
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it('matches the snapshot', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Thanks for this project. I've used it a bunch of times to make and publish components.

I wanted to add an option for an initial jest setup. I use a lot of snapshot testing in my projects and so I wanted that out-of-the-box. I have it all working between Vue 2 and 3 as well as JS and TS.

Running `npm run test` right after setup will run a passing test that creates the first snapshot.