### PR TITLE
feat: add `.gitignore` into template

### DIFF
--- a/templates/library/.gitignore
+++ b/templates/library/.gitignore
@@ -1,0 +1,21 @@
+.DS_Store
+node_modules/
+/dist/
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw*

--- a/templates/single/.gitignore
+++ b/templates/single/.gitignore
@@ -1,0 +1,21 @@
+.DS_Store
+node_modules/
+/dist/
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw*


### PR DESCRIPTION
when using `vue-sfc-rollup`, everything is fabulous—seriously—but the only thing I feel somewhat uncomfortable about is that it does not come along with a `.gitignore` file automatically.