### PR TITLE
Fixed build error for axios 0.21.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-FORKED FROM vue-sfc-rollup
-
-Fixed error:
-(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
-[!] Error: Unexpected token (Note that you need @rollup/plugin-json to import JSON files)
-
 # vue-sfc-rollup
 
 vue-sfc-rollup is a CLI templating utility that scaffolds a minimal setup for compiling a Vue Single File Component (SFC) - or library of multiple SFCs - into a form ready to share via npm. It doesn't assume any particular flavor of CSS or docs generator, so you can use what you're already used to. It's the fastest way to produce npm-ready vue components!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+FORKED FROM vue-sfc-rollup
+
+Fixed error:
+(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
+[!] Error: Unexpected token (Note that you need @rollup/plugin-json to import JSON files)
+
 # vue-sfc-rollup
 
 vue-sfc-rollup is a CLI templating utility that scaffolds a minimal setup for compiling a Vue Single File Component (SFC) - or library of multiple SFCs - into a form ready to share via npm. It doesn't assume any particular flavor of CSS or docs generator, so you can use what you're already used to. It's the fastest way to produce npm-ready vue components!

--- a/templates/library/build/rollup.config.js
+++ b/templates/library/build/rollup.config.js
@@ -7,7 +7,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import babel from '@rollup/plugin-babel';
-const json = require('@rollup/plugin-json');
+import json from '@rollup/plugin-json';
 
 <% if (version === 3) { -%>
 import PostCSS from 'rollup-plugin-postcss';

--- a/templates/library/build/rollup.config.js
+++ b/templates/library/build/rollup.config.js
@@ -7,6 +7,8 @@ import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import babel from '@rollup/plugin-babel';
+const json = require('@rollup/plugin-json');
+
 <% if (version === 3) { -%>
 import PostCSS from 'rollup-plugin-postcss';
 <% } -%>
@@ -109,6 +111,7 @@ if (!argv.format || argv.format === 'es') {
       exports: 'named',
     },
     plugins: [
+      json(),
       replace(baseConfig.plugins.replace),
       ...baseConfig.plugins.preVue,
       vue(baseConfig.plugins.vue),
@@ -152,6 +155,7 @@ if (!argv.format || argv.format === 'cjs') {
       globals,
     },
     plugins: [
+      json(),
       replace(baseConfig.plugins.replace),
       ...baseConfig.plugins.preVue,
 <% if (version === 2) { -%>
@@ -185,6 +189,7 @@ if (!argv.format || argv.format === 'iife') {
       globals,
     },
     plugins: [
+      json(),
       replace(baseConfig.plugins.replace),
       ...baseConfig.plugins.preVue,
       vue(baseConfig.plugins.vue),


### PR DESCRIPTION
Fixed error when import axios 0.21.4 library:

Error
(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
[!] Error: Unexpected token (Note that you need @rollup/plugin-json to import JSON files)