### PR TITLE
Generate a rollup.config.ts file rather than a rollup.config.js file if TypeScript is chosen

### DIFF
--- a/sfc-init.js
+++ b/sfc-init.js
@@ -229,7 +229,7 @@ function scaffold(data) {
   };
   const files = {
     common: [
-      'build/rollup.config.js',
+      { 'build/rollup.config.ts': `build/rollup.config.${data.language}` },
       { 'src/entry.esm.ts': `src/entry.esm.${data.language}` },
       { 'src/entry.ts': `src/entry.${data.language}` },
       { 'dev/serve.ts': `dev/serve.${data.language}` },

--- a/templates/library/build/rollup.config.ts
+++ b/templates/library/build/rollup.config.ts
@@ -1,6 +1,9 @@
 // rollup.config.js
 import fs from 'fs';
 import path from 'path';
+<% if (ts) { -%>
+import { defineConfig } from 'rollup';
+<% } -%>
 import vue from 'rollup-plugin-vue';
 import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
@@ -25,7 +28,7 @@ const esbrowserslist = fs.readFileSync('./.browserslistrc')
 
 // Extract babel preset-env config, to combine with esbrowserslist
 const babelPresetEnvConfig = require('../babel.config')
-  .presets.filter((entry) => entry[0] === '@babel/preset-env')[0][1];
+  .presets.filter((entry<% if (ts) {%>: string | Record<string, any>[]<% } %>) => entry[0] === '@babel/preset-env')[0][1];
 
 const argv = minimist(process.argv.slice(2));
 
@@ -75,7 +78,7 @@ const baseConfig = {
     babel: {
       exclude: 'node_modules/**',
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
-      babelHelpers: 'bundled',
+      babelHelpers: 'bundled'<% if (ts) {%> as 'bundled'<% } %>,
     },
   },
 };
@@ -97,7 +100,7 @@ const globals = {
 };
 
 // Customize configs for individual targets
-const buildFormats = [];
+const buildFormats = <% if (ts) {%>defineConfig([])<% } else { %>[]<% } %>;
 if (!argv.format || argv.format === 'es') {
   const esConfig = {
     ...baseConfig,
@@ -105,8 +108,8 @@ if (!argv.format || argv.format === 'es') {
     external,
     output: {
       file: 'dist/<%-componentName%>.esm.js',
-      format: 'esm',
-      exports: 'named',
+      format: 'esm'<% if (ts) {%> as 'esm'<% } %>,
+      exports: 'named'<% if (ts) {%> as 'named'<% } %>,
     },
     plugins: [
       replace(baseConfig.plugins.replace),
@@ -146,9 +149,9 @@ if (!argv.format || argv.format === 'cjs') {
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.ssr.js',
-      format: 'cjs',
+      format: 'cjs'<% if (ts) {%> as 'cjs'<% } %>,
       name: '<%-componentNamePascal%>',
-      exports: 'auto',
+      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
       globals,
     },
     plugins: [
@@ -179,9 +182,9 @@ if (!argv.format || argv.format === 'iife') {
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.min.js',
-      format: 'iife',
+      format: 'iife'<% if (ts) {%> as 'iife'<% } %>,
       name: '<%-componentNamePascal%>',
-      exports: 'auto',
+      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
       globals,
     },
     plugins: [

--- a/templates/library/build/rollup.config.ts
+++ b/templates/library/build/rollup.config.ts
@@ -1,4 +1,4 @@
-// rollup.config.js
+// rollup.config.(js|ts)
 import fs from 'fs';
 import path from 'path';
 <% if (ts) { -%>

--- a/templates/library/build/rollup.config.ts
+++ b/templates/library/build/rollup.config.ts
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'path';
 <% if (ts) { -%>
-import { defineConfig } from 'rollup';
+import { defineConfig, RollupOptions } from 'rollup';
 <% } -%>
 import vue from 'rollup-plugin-vue';
 import alias from '@rollup/plugin-alias';
@@ -34,7 +34,7 @@ const argv = minimist(process.argv.slice(2));
 
 const projectRoot = path.resolve(__dirname, '..');
 
-const baseConfig = {
+const baseConfig<% if (ts) {%>: RollupOptions<% } %> = {
   input: 'src/entry.<% if (ts) {%>ts<% } else { %>js<% } %>',
   plugins: {
     preVue: [
@@ -78,7 +78,7 @@ const baseConfig = {
     babel: {
       exclude: 'node_modules/**',
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
-      babelHelpers: 'bundled'<% if (ts) {%> as 'bundled'<% } %>,
+      babelHelpers: 'bundled',
     },
   },
 };
@@ -102,14 +102,14 @@ const globals = {
 // Customize configs for individual targets
 const buildFormats = <% if (ts) {%>defineConfig([])<% } else { %>[]<% } %>;
 if (!argv.format || argv.format === 'es') {
-  const esConfig = {
+  const esConfig<% if (ts) {%>: RollupOptions<% } %> = {
     ...baseConfig,
     input: 'src/entry.esm.<% if (ts) {%>ts<% } else { %>js<% } %>',
     external,
     output: {
       file: 'dist/<%-componentName%>.esm.js',
-      format: 'esm'<% if (ts) {%> as 'esm'<% } %>,
-      exports: 'named'<% if (ts) {%> as 'named'<% } %>,
+      format: 'esm',
+      exports: 'named',
     },
     plugins: [
       replace(baseConfig.plugins.replace),
@@ -143,15 +143,15 @@ if (!argv.format || argv.format === 'es') {
 }
 
 if (!argv.format || argv.format === 'cjs') {
-  const umdConfig = {
+  const umdConfig<% if (ts) {%>: RollupOptions<% } %> = {
     ...baseConfig,
     external,
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.ssr.js',
-      format: 'cjs'<% if (ts) {%> as 'cjs'<% } %>,
+      format: 'cjs',
       name: '<%-componentNamePascal%>',
-      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
+      exports: 'auto',
       globals,
     },
     plugins: [
@@ -176,15 +176,15 @@ if (!argv.format || argv.format === 'cjs') {
 }
 
 if (!argv.format || argv.format === 'iife') {
-  const unpkgConfig = {
+  const unpkgConfig<% if (ts) {%>: RollupOptions<% } %> = {
     ...baseConfig,
     external,
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.min.js',
-      format: 'iife'<% if (ts) {%> as 'iife'<% } %>,
+      format: 'iife',
       name: '<%-componentNamePascal%>',
-      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
+      exports: 'auto',
       globals,
     },
     plugins: [

--- a/templates/library/library-package.json
+++ b/templates/library/library-package.json
@@ -20,10 +20,10 @@
   "scripts": {
     "serve": "vue-cli-service serve dev/serve.<% if (ts) { %>ts<% } else { %>js<% } %>",
     "prebuild": "rimraf ./dist",
-    "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
-    "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format cjs",
-    "build:es": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format es",
-    "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"<% if (ts) { %>,
+    "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %>",
+    "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %> --format cjs",
+    "build:es": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %> --format es",
+    "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %> --format iife"<% if (ts) { %>,
     "postbuild": "rimraf ./dist/types/dev ./dist/types/src/entry.d.ts"<% } %>
   },
 

--- a/templates/library/library-package.json
+++ b/templates/library/library-package.json
@@ -41,6 +41,9 @@
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^2.4.2",
+<% if (ts) { -%>
+    "@rollup/plugin-typescript": "^8.3.0",
+<% } -%>
     "@vue/cli-plugin-babel": "^4.5.13",
 <% if (ts) { -%>
     "@vue/cli-plugin-typescript": "^4.5.13",

--- a/templates/single/build/rollup.config.ts
+++ b/templates/single/build/rollup.config.ts
@@ -1,6 +1,9 @@
 // rollup.config.js
 import fs from 'fs';
 import path from 'path';
+<% if (ts) { -%>
+import { defineConfig } from 'rollup';
+<% } -%>
 import vue from 'rollup-plugin-vue';
 import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
@@ -25,7 +28,7 @@ const esbrowserslist = fs.readFileSync('./.browserslistrc')
 
 // Extract babel preset-env config, to combine with esbrowserslist
 const babelPresetEnvConfig = require('../babel.config')
-  .presets.filter((entry) => entry[0] === '@babel/preset-env')[0][1];
+  .presets.filter((entry<% if (ts) {%>: string | Record<string, any>[]<% } %>) => entry[0] === '@babel/preset-env')[0][1];
 
 const argv = minimist(process.argv.slice(2));
 
@@ -75,7 +78,7 @@ const baseConfig = {
     babel: {
       exclude: 'node_modules/**',
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
-      babelHelpers: 'bundled',
+      babelHelpers: 'bundled'<% if (ts) {%> as 'bundled'<% } %>,
     },
   },
 };
@@ -97,7 +100,7 @@ const globals = {
 };
 
 // Customize configs for individual targets
-const buildFormats = [];
+const buildFormats = <% if (ts) {%>defineConfig([])<% } else { %>[]<% } %>;
 if (!argv.format || argv.format === 'es') {
   const esConfig = {
     ...baseConfig,
@@ -105,8 +108,8 @@ if (!argv.format || argv.format === 'es') {
     external,
     output: {
       file: 'dist/<%-componentName%>.esm.js',
-      format: 'esm',
-      exports: 'named',
+      format: 'esm'<% if (ts) {%> as 'esm'<% } %>,
+      exports: 'named'<% if (ts) {%> as 'named'<% } %>,
     },
     plugins: [
       replace(baseConfig.plugins.replace),
@@ -146,9 +149,9 @@ if (!argv.format || argv.format === 'cjs') {
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.ssr.js',
-      format: 'cjs',
+      format: 'cjs'<% if (ts) {%> as 'cjs'<% } %>,
       name: '<%-componentNamePascal%>',
-      exports: 'auto',
+      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
       globals,
     },
     plugins: [
@@ -179,9 +182,9 @@ if (!argv.format || argv.format === 'iife') {
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.min.js',
-      format: 'iife',
+      format: 'iife'<% if (ts) {%> as 'iife'<% } %>,
       name: '<%-componentNamePascal%>',
-      exports: 'auto',
+      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
       globals,
     },
     plugins: [

--- a/templates/single/build/rollup.config.ts
+++ b/templates/single/build/rollup.config.ts
@@ -1,4 +1,4 @@
-// rollup.config.js
+// rollup.config.(js|ts)
 import fs from 'fs';
 import path from 'path';
 <% if (ts) { -%>

--- a/templates/single/build/rollup.config.ts
+++ b/templates/single/build/rollup.config.ts
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'path';
 <% if (ts) { -%>
-import { defineConfig } from 'rollup';
+import { defineConfig, RollupOptions } from 'rollup';
 <% } -%>
 import vue from 'rollup-plugin-vue';
 import alias from '@rollup/plugin-alias';
@@ -34,7 +34,7 @@ const argv = minimist(process.argv.slice(2));
 
 const projectRoot = path.resolve(__dirname, '..');
 
-const baseConfig = {
+const baseConfig<% if (ts) {%>: RollupOptions<% } %> = {
   input: 'src/entry.<% if (ts) {%>ts<% } else { %>js<% } %>',
   plugins: {
     preVue: [
@@ -78,7 +78,7 @@ const baseConfig = {
     babel: {
       exclude: 'node_modules/**',
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
-      babelHelpers: 'bundled'<% if (ts) {%> as 'bundled'<% } %>,
+      babelHelpers: 'bundled',
     },
   },
 };
@@ -102,14 +102,14 @@ const globals = {
 // Customize configs for individual targets
 const buildFormats = <% if (ts) {%>defineConfig([])<% } else { %>[]<% } %>;
 if (!argv.format || argv.format === 'es') {
-  const esConfig = {
+  const esConfig<% if (ts) {%>: RollupOptions<% } %> = {
     ...baseConfig,
     input: 'src/entry.esm.<% if (ts) {%>ts<% } else { %>js<% } %>',
     external,
     output: {
       file: 'dist/<%-componentName%>.esm.js',
-      format: 'esm'<% if (ts) {%> as 'esm'<% } %>,
-      exports: 'named'<% if (ts) {%> as 'named'<% } %>,
+      format: 'esm',
+      exports: 'named',
     },
     plugins: [
       replace(baseConfig.plugins.replace),
@@ -143,15 +143,15 @@ if (!argv.format || argv.format === 'es') {
 }
 
 if (!argv.format || argv.format === 'cjs') {
-  const umdConfig = {
+  const umdConfig<% if (ts) {%>: RollupOptions<% } %> = {
     ...baseConfig,
     external,
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.ssr.js',
-      format: 'cjs'<% if (ts) {%> as 'cjs'<% } %>,
+      format: 'cjs',
       name: '<%-componentNamePascal%>',
-      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
+      exports: 'auto',
       globals,
     },
     plugins: [
@@ -176,15 +176,15 @@ if (!argv.format || argv.format === 'cjs') {
 }
 
 if (!argv.format || argv.format === 'iife') {
-  const unpkgConfig = {
+  const unpkgConfig<% if (ts) {%>: RollupOptions<% } %> = {
     ...baseConfig,
     external,
     output: {
       compact: true,
       file: 'dist/<%-componentName%>.min.js',
-      format: 'iife'<% if (ts) {%> as 'iife'<% } %>,
+      format: 'iife',
       name: '<%-componentNamePascal%>',
-      exports: 'auto'<% if (ts) {%> as 'auto'<% } %>,
+      exports: 'auto',
       globals,
     },
     plugins: [

--- a/templates/single/single-package.json
+++ b/templates/single/single-package.json
@@ -20,10 +20,10 @@
   "scripts": {
     "serve": "vue-cli-service serve dev/serve.<% if (ts) { %>ts<% } else { %>js<% } %>",
     "prebuild": "rimraf ./dist",
-    "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",
-    "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format cjs",
-    "build:es": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format es",
-    "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"<% if (ts) { %>,
+    "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %>",
+    "build:ssr": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %> --format cjs",
+    "build:es": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %> --format es",
+    "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.<% if (ts) { %>ts --configPlugin typescript<% } else { %>js<% } %> --format iife"<% if (ts) { %>,
     "postbuild": "rimraf ./dist/types/dev ./dist/types/src/entry.d.ts"<% } %>
   },
 

--- a/templates/single/single-package.json
+++ b/templates/single/single-package.json
@@ -41,6 +41,9 @@
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^2.4.2",
+<% if (ts) { -%>
+    "@rollup/plugin-typescript": "^8.3.0",
+<% } -%>
     "@vue/cli-plugin-babel": "^4.5.13",
 <% if (ts) { -%>
     "@vue/cli-plugin-typescript": "^4.5.13",


### PR DESCRIPTION
No worries if this isn't anything you want, but I thought it might be a good idea to generate a `rollup.config.ts` file rather than a `rollup.config.js` file for those deciding to choose TypeScript as their language.

There's an issue that I'm not sure how best to resolve whereby it complains that `preVue`, `vue` and `postVue` are not valid types on `plugins`. Could use some input on this.

Also, currently, the generated `rollup.config.ts` file shows a TS error on the `emitDeclarationOnly: true`, saying it doesn't exist as an option, and for the life of me, I have no idea how to resolve it.

- https://rollupjs.org/guide/en/#--configplugin-plugin